### PR TITLE
Sylius inside vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.vagrant/
+/sylius/*
+!/sylius/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /.vagrant/
-/sylius/*
-!/sylius/.gitkeep
+/sites/*
+!/sites/.gitkeep

--- a/README.md
+++ b/README.md
@@ -12,15 +12,9 @@ This configuration includes following software:
 
 # Usage
 
-First you need to download a [Sylius standard project](https://github.com/Sylius/Sylius-Standard) (`-n` flag for no interaction mode):
+First you need to download this repository
 ```bash
-$ composer create-project -s beta -n sylius/sylius-standard acme
-```
-
-Then clone this repository inside newly created project:
-```bash
-$ cd acme
-$ git clone git@github.com:Sylius/Vagrant.git vagrant
+$ git clone git@github.com:Sylius/Vagrant.git
 ```
 
 And build Vagrant:
@@ -35,7 +29,9 @@ While waiting for Vagrant to start up, you should add an entry into /etc/hosts f
 10.0.0.200      sylius.dev
 ```
 
-From now you should be able to access your Sylius project at [http://sylius.dev/app_dev.php](http://sylius.dev/app_dev.php)
+From now you should be able to access your Sylius project at [http://sylius.dev/app_dev.php](http://sylius.dev/app_dev.php).
+
+Your newly created project is available under `sylius` folder.
 
 Installing your assets manually
 
@@ -47,18 +43,16 @@ $ vagrant ssh -c 'cd /var/www/sylius && ./node_modules/.bin/gulp'
 
 ### Beware
 
-The default vagrant configuration uses a database connection with user `root` and password `vagrant`. If you create a project without interaction (`-n` flag in `composer create-project`) or leave a null value for password, vagrant’s Sylius setup will take care of password change. Otherwise, you will have to change it on your own.
-
 Using Symfony2 inside Vagrant can be slow due to synchronisation delay incurred by NFS. To avoid this, both locations have been moved to a shared memory segment under ``/dev/shm/sylius``.
 
-To view the application logs, run the following commands:
+To view the application logs, run the following commands (inside Vagrant):
 
 ```bash
 $ tail -f /dev/shm/sylius/app/logs/prod.log
 $ tail -f /dev/shm/sylius/app/logs/dev.log
 ```
 
-To view the apache logs, run the following commands:
+To view the apache logs, run the following commands (inside Vagrant):
 
 ```bash
 $ tail -f /var/log/apache2/sylius_error.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
         end
 
-        sylius_config.vm.synced_folder "sylius/", "/var/www/sylius", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'fsc', 'nolock', 'actimeo=2']
+        sylius_config.vm.synced_folder "sites/", "/var/www/sites", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'fsc', 'nolock', 'actimeo=2']
         sylius_config.vm.network "private_network", ip: "10.0.0.200"
 
         # Shell provisioning

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
         end
 
-        sylius_config.vm.synced_folder "../", "/var/www/sylius", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'fsc', 'nolock', 'actimeo=2']
+        sylius_config.vm.synced_folder "sylius/", "/var/www/sylius", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'fsc', 'nolock', 'actimeo=2']
         sylius_config.vm.network "private_network", ip: "10.0.0.200"
 
         # Shell provisioning

--- a/shell_provisioner/config/apache/sylius.vhost.conf
+++ b/shell_provisioner/config/apache/sylius.vhost.conf
@@ -1,7 +1,7 @@
 <VirtualHost *:80>
 
     ServerName sylius.dev
-    DocumentRoot /var/www/sylius/web
+    DocumentRoot /var/www/sites/sylius/web
     EnableSendfile off
 
     <Directory />
@@ -9,7 +9,7 @@
         AllowOverride None
     </Directory>
 
-    <Directory /var/www/sylius/web>
+    <Directory /var/www/sites/sylius/web>
         Options Indexes FollowSymLinks MultiViews
         Options -Indexes
 
@@ -32,6 +32,6 @@
 
     CustomLog /var/log/apache2/sylius_access.log combined
 
-    ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/var/run/php/php7.0-fpm.sock|fcgi://localhost/var/www/sylius/web/
+    ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/var/run/php/php7.0-fpm.sock|fcgi://localhost/var/www/sites/sylius/web/
 
 </VirtualHost>

--- a/shell_provisioner/module/sylius.sh
+++ b/shell_provisioner/module/sylius.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-cd /var/www/sylius
+cd /var/www/sites
 
-rm .gitkeep
+composer create-project -s dev -n sylius/sylius-standard ./sylius 
 
-composer create-project -s beta -n sylius/sylius-standard .
+cd sylius
 
 sed -i "s/database_password: null/database_password: vagrant/g" app/config/parameters.yml
 
@@ -12,6 +12,3 @@ php bin/console sylius:install --no-interaction
 php bin/console sylius:fixtures:load
 npm install
 npm run gulp
-
-cd ../
-git update-index --assume-unchanged sylius/.gitkeep

--- a/shell_provisioner/module/sylius.sh
+++ b/shell_provisioner/module/sylius.sh
@@ -2,7 +2,9 @@
 
 cd /var/www/sylius
 
-composer install
+rm .gitkeep
+
+composer create-project -s beta -n sylius/sylius-standard .
 
 sed -i "s/database_password: null/database_password: vagrant/g" app/config/parameters.yml
 
@@ -10,3 +12,6 @@ php bin/console sylius:install --no-interaction
 php bin/console sylius:fixtures:load
 npm install
 npm run gulp
+
+cd ../
+git update-index --assume-unchanged sylius/.gitkeep


### PR DESCRIPTION
With these changes, no previous steps would be required. It would be enough to just download repo and run `vagrant up`. 