### PR TITLE
Install beta instead of dev master

### DIFF
--- a/shell_provisioner/module/sylius.sh
+++ b/shell_provisioner/module/sylius.sh
@@ -2,7 +2,7 @@
 
 cd /var/www/sites
 
-composer create-project -s dev -n sylius/sylius-standard ./sylius 
+composer create-project -s beta -n sylius/sylius-standard ./sylius 
 
 cd sylius
 


### PR DESCRIPTION
I have forgotten to revert this change. It should be merged if we would like to present a latest beta instead of dev master on Vagrant