### PR TITLE
Update all occurrences of .dev to .test

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ $ vagrant up
 While waiting for Vagrant to start up, you should add an entry into /etc/hosts file on the host machine.
 
 ```
-10.0.0.200      sylius.dev
+10.0.0.200      sylius.test
 ```
 
-From now you should be able to access your Sylius project at [http://sylius.dev/app_dev.php](http://sylius.dev/app_dev.php).
+From now you should be able to access your Sylius project at [http://sylius.test/app_dev.php](http://sylius.test/app_dev.php).
 
 Your newly created project is available under `sylius` folder.
 

--- a/shell_provisioner/config/apache/sylius.vhost.conf
+++ b/shell_provisioner/config/apache/sylius.vhost.conf
@@ -1,6 +1,6 @@
 <VirtualHost *:80>
 
-    ServerName sylius.dev
+    ServerName sylius.test
     DocumentRoot /var/www/sites/sylius/web
     EnableSendfile off
 

--- a/shell_provisioner/run.sh
+++ b/shell_provisioner/run.sh
@@ -8,7 +8,7 @@ CONFIG_PATH='/vagrant/shell_provisioner/config'
 GUEST_IP='10.0.0.200'
 
 #Config
-APP_DOMAIN='sylius.dev'
+APP_DOMAIN='sylius.test'
 APP_DBNAME='sylius'
 
 # Adding an entry here executes the corresponding .sh file in MODULE_PATH


### PR DESCRIPTION
New preloaded .dev gTLD HSTS causing issues for some web browsers
https://chromium-review.googlesource.com/c/chromium/src/+/669923

It seems to be generally accepted to switch to `.test` instead.
https://tools.ietf.org/html/rfc2606

More info: https://ma.ttias.be/chrome-force-dev-domains-https-via-preloaded-hsts/

Fixes #16

I submitted this PR as #17 fixes two issues at once and uses `.local` which isn't in the RFC so may possibly cause more issues down the line.