### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@
 # vi: set ft=ruby :
 
 VAGRANTFILE_API_VERSION = "2"
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.define :sylius do |sylius_config|


### PR DESCRIPTION
Update hashicorp old  default URL: https://atlas.hashicorp.com/
to:
https://vagrantcloud.com.

Fixes errror when `vagrant up`:
The box 'debian/jessie64' could not be found or
could not be accessed in the remote catalog. If this is a private
box on HashiCorp's Atlas, please verify you're logged in via
`vagrant login`. Also, please double-check the name. The expanded
URL and error message are shown below:

URL: ["https://atlas.hashicorp.com/debian/jessie64"]
Error: The requested URL returned error: 404 Not Found
