### PR TITLE
BUGFIX: Fix database credentials for install

### DIFF
--- a/shell_provisioner/sylius/install.sh
+++ b/shell_provisioner/sylius/install.sh
@@ -2,7 +2,7 @@
 
 cd /var/www/sites/sylius
 
-sed -i "s/database_password: null/database_password: vagrant/g" app/config/parameters.yml
+sed -i "s/database_password: '%env(SYLIUS_DATABASE_PASSWORD)%'/database_password: vagrant/g" app/config/parameters.yml
 
 php bin/console sylius:install --no-interaction
 php bin/console sylius:fixtures:load


### PR DESCRIPTION
The initial installation of the vagrant instance now gets the correct database credentials.
So to instance is up and running after first vagrant up.

Fixes: #22